### PR TITLE
fix: clean work dir before clone to survive container restarts

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -42,7 +42,7 @@ if [[ -n "$GIT_TOKEN" ]]; then
   SOURCE_URL="${PROTOCOL}://${GIT_TOKEN}@${GIT_HOST}${GIT_PATH}"
 fi
 
-mkdir -p "$WORK_DIR"
+rm -rf "$WORK_DIR"
 if [[ -n "$BRANCH" ]]; then
   git clone --branch "$BRANCH" --depth 1 "$SOURCE_URL" "$WORK_DIR"
 else


### PR DESCRIPTION
## Problem

On container restarts (e.g., after a CrashLoopBackOff), the clone phase fails with:

```
fatal: destination path '/usercontent/app' already exists and is not an empty directory
```

This happens because `mkdir -p "$WORK_DIR"` is a no-op when the directory exists from the previous run, so `git clone` finds a non-empty destination and refuses to proceed.

## Fix

Replace `mkdir -p "$WORK_DIR"` with `rm -rf "$WORK_DIR"` to ensure a clean state before each clone. `git clone` creates the target directory itself, so the explicit `mkdir` is unnecessary.

This makes the entrypoint idempotent across container restarts.