### PR TITLE
fix: wait for loading server to exit before starting app

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -103,6 +103,7 @@ fi
 
 # ---- Run phase ----
 kill $LOADING_PID 2>/dev/null || true
+wait $LOADING_PID 2>/dev/null || true
 trap - EXIT
 
 if [[ -n "$OSC_ENTRY" ]]; then


### PR DESCRIPTION
## Summary
- Adds `wait $LOADING_PID` after `kill` in the run phase to ensure the loading server has fully exited and released port 8080 before the Go app starts
- Without this, the Go app hits `listen tcp :8080: bind: address already in use` due to a race between kill and port release

## Test plan
- [ ] Deploy a Go app instance and verify it starts without port conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)