### PR TITLE
feat: write .commit-info.json after git clone

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -13,6 +13,23 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Write commit metadata to a well-known file for platform visibility
+write_commit_info() {
+  local repo_dir="$1"
+  if [ -d "$repo_dir/.git" ]; then
+    git -C "$repo_dir" log -5 --format='{"sha":"%H","shortSha":"%h","message":"%s","author":"%an","date":"%aI"}' \
+      | jq -s '{
+          sha: .[0].sha,
+          shortSha: .[0].shortSha,
+          message: .[0].message,
+          author: .[0].author,
+          date: .[0].date,
+          recentCommits: .
+        }' > "$repo_dir/.commit-info.json" 2>/dev/null || true
+    echo "Commit info: $(jq -r '.shortSha + " - " + .message' "$repo_dir/.commit-info.json" 2>/dev/null || echo 'unavailable')"
+  fi
+}
+
 # ---- Clone phase ----
 SOURCE_URL="${SOURCE_URL:-$GITHUB_URL}"
 if [[ -z "$SOURCE_URL" ]]; then
@@ -48,6 +65,8 @@ if [[ -n "$BRANCH" ]]; then
 else
   git clone --depth 1 "$SOURCE_URL" "$WORK_DIR"
 fi
+
+write_commit_info "$WORK_DIR"
 
 # ---- Sub-path support ----
 BUILD_DIR="$WORK_DIR"


### PR DESCRIPTION
## Summary

- Adds `write_commit_info()` function to `scripts/docker-entrypoint.sh`
- After `git clone` completes, writes `.commit-info.json` to the cloned repo directory containing: `sha`, `shortSha`, `message`, `author`, `date`, and `recentCommits` array
- Uses `jq` (already present in this runner) to format output; failures are silenced with `|| true` so they never block the build
- Logs a single line (`Commit info: <shortSha> - <message>`) for quick visibility in build logs
- With `--depth 1` clone, `recentCommits` will contain exactly one entry; the schema supports up to 5 for non-shallow clones

Closes #4

## Test plan

- [ ] Build the Docker image and run a container with a valid `SOURCE_URL`; verify `.commit-info.json` exists in `/usercontent/app` and contains correct commit metadata
- [ ] Verify build proceeds normally when `.git` directory is absent (function no-ops)
- [ ] Verify a clone failure does not leave partial `.commit-info.json` blocking the run (function exits cleanly via `|| true`)

🤖 Generated with [Claude Code](https://claude.ai/code)