### PR TITLE
feat: write .commit-info.json after git clone for deploy-manager integration

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -13,6 +13,38 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Write commit metadata to a well-known file for platform visibility
+write_commit_info() {
+  local repo_dir="$1"
+  if [ -d "$repo_dir/.git" ]; then
+    local sha shortSha msg author date recentCommits
+    sha=$(git -C "$repo_dir" rev-parse HEAD 2>/dev/null) || return 0
+    shortSha=$(git -C "$repo_dir" rev-parse --short HEAD 2>/dev/null) || return 0
+    msg=$(git -C "$repo_dir" log -1 --format='%s' 2>/dev/null) || return 0
+    author=$(git -C "$repo_dir" log -1 --format='%an' 2>/dev/null) || return 0
+    date=$(git -C "$repo_dir" log -1 --format='%aI' 2>/dev/null) || return 0
+    recentCommits=$(git -C "$repo_dir" log -5 --format='%H' 2>/dev/null | while read -r c_sha; do
+      jq -n \
+        --arg sha "$c_sha" \
+        --arg shortSha "$(git -C "$repo_dir" rev-parse --short "$c_sha" 2>/dev/null)" \
+        --arg message "$(git -C "$repo_dir" log -1 --format='%s' "$c_sha" 2>/dev/null)" \
+        --arg author "$(git -C "$repo_dir" log -1 --format='%an' "$c_sha" 2>/dev/null)" \
+        --arg date "$(git -C "$repo_dir" log -1 --format='%aI' "$c_sha" 2>/dev/null)" \
+        '{sha:$sha,shortSha:$shortSha,message:$message,author:$author,date:$date}'
+    done | jq -s '.' 2>/dev/null) || recentCommits='[]'
+    jq -n \
+      --arg sha "$sha" \
+      --arg shortSha "$shortSha" \
+      --arg message "$msg" \
+      --arg author "$author" \
+      --arg date "$date" \
+      --argjson recentCommits "$recentCommits" \
+      '{sha:$sha,shortSha:$shortSha,message:$message,author:$author,date:$date,recentCommits:$recentCommits}' \
+      > "$repo_dir/.commit-info.json" 2>/dev/null || true
+    echo "Commit info: $(jq -r '.shortSha + " - " + .message' "$repo_dir/.commit-info.json" 2>/dev/null || echo 'unavailable')"
+  fi
+}
+
 # ---- Clone phase ----
 SOURCE_URL="${SOURCE_URL:-$GITHUB_URL}"
 if [[ -z "$SOURCE_URL" ]]; then
@@ -48,6 +80,8 @@ if [[ -n "$BRANCH" ]]; then
 else
   git clone --depth 1 "$SOURCE_URL" "$WORK_DIR"
 fi
+
+write_commit_info "$WORK_DIR"
 
 # ---- Sub-path support ----
 BUILD_DIR="$WORK_DIR"


### PR DESCRIPTION
## Summary

- Adds `write_commit_info` function to `docker-entrypoint.sh` that writes `.commit-info.json` after git clone
- File contains HEAD commit SHA, short SHA, message, author, date, and up to 5 recent commits
- Uses `jq` (already installed in the Docker image) for proper JSON escaping of commit messages
- Matches the format already used by web-runner, python-runner, wasm-runner, and dotnet-runner

This is Phase 1 of epic Eyevinn/osaas-deploy-manager#321 ("Show deployed commit SHA and log in My Apps"). The deploy-manager will read this file via K8s exec to surface commit info in the My Apps UI.

## Test plan

- [ ] Build Docker image and verify `.commit-info.json` is written to `/usercontent/app/.commit-info.json` after clone
- [ ] Verify JSON contains valid `sha`, `shortSha`, `message`, `author`, `date`, and `recentCommits` fields
- [ ] Verify commit messages with special characters (quotes, backslashes) are properly escaped via jq
- [ ] Verify the function is a no-op when `.git` directory doesn't exist (S3 source)

🤖 Generated with [Claude Code](https://claude.ai/code)