### PR TITLE
fix: scrub PAT from git origin remote after clone

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -81,6 +81,11 @@ else
   git clone --depth 1 "$SOURCE_URL" "$WORK_DIR"
 fi
 
+# Scrub PAT from origin remote — token must not persist to .git/config
+if [[ -n "$GIT_TOKEN" ]]; then
+  git -C "$WORK_DIR" remote set-url origin "${PROTOCOL}://${GIT_HOST}${GIT_PATH}"
+fi
+
 write_commit_info "$WORK_DIR"
 
 # ---- Sub-path support ----


### PR DESCRIPTION
## Summary

After a successful git clone with a token-embedded URL, the token is stored persistently in \`.git/config\`. This PR adds a \`git remote set-url\` call immediately after every clone to strip the credentials from the stored origin URL.

## Change

In \`scripts/docker-entrypoint.sh\`, after the clone block:
\`\`\`bash
# Scrub PAT from origin remote — token must not persist to .git/config
if [[ -n "\$GIT_TOKEN" ]]; then
  git -C "\$WORK_DIR" remote set-url origin "\${PROTOCOL}://\${GIT_HOST}\${GIT_PATH}"
fi
\`\`\`

Closes #7

🤖 Generated with [Claude Code](https://claude.ai/code)